### PR TITLE
Move cache and source dirs for UWP port

### DIFF
--- a/Jazz2/Jazz2/ContentResolver.cpp
+++ b/Jazz2/Jazz2/ContentResolver.cpp
@@ -13,6 +13,10 @@
 #include "../nCine/Graphics/ITextureLoader.h"
 #include "../nCine/Base/Random.h"
 
+#if defined(DEATH_TARGET_WINDOWS_RT)
+#include "../nCine/Uwp/UwpFunc.h"
+#endif
+
 #if defined(DEATH_TARGET_SSE42) || defined(DEATH_TARGET_AVX)
 #	define RAPIDJSON_SSE42
 #elif defined(DEATH_TARGET_SSE2)
@@ -62,6 +66,13 @@ namespace Jazz2
 			_cachePath = "Cache/"_s;
 			_sourcePath = "Source/"_s;
 		}
+#elif defined(DEATH_TARGET_WINDOWS_RT)
+		char localfolder[255];
+		uwp_get_localfolder(localfolder);
+		String localStorage = String(localfolder);
+		_cachePath = fs::JoinPath(localStorage, "Cache/"_s);
+		_sourcePath = fs::JoinPath(localStorage, "Source/"_s);
+		_contentPath = "Content/"_s;
 #endif
 
 		CompileShaders();

--- a/Jazz2/Jazz2/ContentResolver.h
+++ b/Jazz2/Jazz2/ContentResolver.h
@@ -250,7 +250,7 @@ namespace Jazz2
 		}
 
 		StringView GetContentPath() const {
-#if defined(DEATH_TARGET_UNIX)
+#if defined(DEATH_TARGET_UNIX) || defined(DEATH_TARGET_WINDOWS_RT)
 			return _contentPath;
 #else
 			return "Content/"_s;
@@ -258,7 +258,7 @@ namespace Jazz2
 		}
 
 		StringView GetCachePath() const {
-#if defined(DEATH_TARGET_UNIX)
+#if defined(DEATH_TARGET_UNIX) || defined(DEATH_TARGET_WINDOWS_RT)
 			return _cachePath;
 #else
 			return "Cache/"_s;
@@ -266,7 +266,7 @@ namespace Jazz2
 		}
 
 		StringView GetSourcePath() const {
-#if defined(DEATH_TARGET_UNIX)
+#if defined(DEATH_TARGET_UNIX) || defined(DEATH_TARGET_WINDOWS_RT)
 			return _sourcePath;
 #else
 			return "Source/"_s;
@@ -297,7 +297,7 @@ namespace Jazz2
 		std::unique_ptr<UI::Font> _fonts[(int)FontType::Count];
 		std::unique_ptr<Shader> _precompiledShaders[(int)PrecompiledShader::Count];
 
-#if defined(DEATH_TARGET_UNIX)
+#if defined(DEATH_TARGET_UNIX) || defined(DEATH_TARGET_WINDOWS_RT)
 		String _contentPath;
 		String _cachePath;
 		String _sourcePath;

--- a/Jazz2/nCine/Uwp/UwpFunc.cpp
+++ b/Jazz2/nCine/Uwp/UwpFunc.cpp
@@ -1,0 +1,27 @@
+#include "uwpfunc.h"
+#include <string>
+#include <windows.h>
+#include <fileapifromapp.h>
+
+using namespace Windows::System;
+using namespace Windows::Foundation;
+using namespace Windows::Storage;
+
+//Platform::String^ local_folder = Windows::Storage::ApplicationData::Current->LocalFolder->Path+L"\\";
+extern "C" {
+	void uwp_get_localfolder(char* output)
+	{
+		Platform::String^ local_folder = Windows::Storage::ApplicationData::Current->LocalFolder->Path;
+		std::wstring ws(local_folder->Data());
+		std::string str(ws.begin(), ws.end());
+		int a = str.length();
+		strcpy(output, str.c_str());
+	}
+	void uwp_create_save_dir(void)
+	{
+		Platform::String^ local_folder = Windows::Storage::ApplicationData::Current->LocalFolder->Path + L"\\Cache";
+		CreateDirectoryFromAppW(local_folder->Data(), NULL);
+		local_folder = Windows::Storage::ApplicationData::Current->LocalFolder->Path + L"\\Source";
+		CreateDirectoryFromAppW(local_folder->Data(), NULL);
+	}
+}

--- a/Jazz2/nCine/Uwp/UwpFunc.h
+++ b/Jazz2/nCine/Uwp/UwpFunc.h
@@ -1,0 +1,15 @@
+#pragma once
+#ifndef _UWP_FUNC_H
+#define _UWP_FUNC_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+	void uwp_get_localfolder(char* output);
+	void uwp_create_save_dir(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif _UWP_FUNC_H


### PR DESCRIPTION
Moved the cache and source dirs for the UWP port to the apps localstate folder as they can be written to by the app and the user.
The make file and buildscript must be adjusted but I am not sure how to do it.
`UwpFunc.cpp` needs to be set to consume windows runtime extensions `\ZW` compiler argument and be compiled with c++17.