### PR TITLE
Adjust FastFire mechanics

### DIFF
--- a/Sources/Jazz2/Actors/Player.cpp
+++ b/Sources/Jazz2/Actors/Player.cpp
@@ -2958,7 +2958,7 @@ namespace Jazz2::Actors
 		} else {
 			_externalForce.X = 0.0f;
 			_speed.Y = 0.0f;
-
+			ZeroFastFire();
 			PlayPlayerSfx("Die"_s, 1.3f);
 		}
 
@@ -3137,7 +3137,7 @@ namespace Jazz2::Actors
 
 	bool Player::AddFastFire(int count)
 	{
-		const int FastFireLimit = 9;
+		const int FastFireLimit = 17;
 
 		int current = (_weaponUpgrades[(int)WeaponType::Blaster] >> 1);
 		if (current >= FastFireLimit) {
@@ -3151,6 +3151,11 @@ namespace Jazz2::Actors
 		PlaySfx("PickupAmmo"_s);
 
 		return true;
+	}
+
+	void Player::ZeroFastFire()
+	{
+		_weaponUpgrades[(int)WeaponType::Blaster] = 0;
 	}
 
 	void Player::MorphTo(PlayerType type)

--- a/Sources/Jazz2/Actors/Player.h
+++ b/Sources/Jazz2/Actors/Player.h
@@ -111,6 +111,7 @@ namespace Jazz2::Actors
 		bool AddAmmo(WeaponType weaponType, int16_t count);
 		void AddWeaponUpgrade(WeaponType weaponType, uint8_t upgrade);
 		bool AddFastFire(int count);
+		void ZeroFastFire();
 		void MorphTo(PlayerType type);
 		void MorphRevert();
 		bool SetDizzyTime(float time);


### PR DESCRIPTION
Hi!
I created this to mimic behavior of FastFire from my memory of JJ2:TSF - IIRC it was about that fast (if you were good enough and not dying left and right), but the penalty for dying was that it was reset to start value (so, very very slow in comparison).
Not sure if my code is okay (not a programmer :( ) - at least it compiles, but i didn't check it (since I'm on my first playthrough now I just want to finish it first) so please if you're willing to incorporate this, proceed with caution :)

Also, thinking about it now, I'm not sure if the actual blaster upgrade was retained or lost as well, would have to install the original, and that's gonna take me a while...