### PR TITLE
Use union for int-float type conversion

### DIFF
--- a/Sources/nCine/Base/Algorithms.cpp
+++ b/Sources/nCine/Base/Algorithms.cpp
@@ -247,12 +247,16 @@ namespace nCine
 
 	static inline std::uint32_t as_uint32(const float x)
 	{
-		return *(std::uint32_t*)&x;
+		union {float f; uint32_t i;} u;
+		u.f = x;
+		return u.i;
 	}
 
 	static inline float as_float(const std::uint32_t x)
 	{
-		return *(float*)&x;
+		union {float f; uint32_t i;} u;
+		u.i = x;
+		return u.f;
 	}
 
 	float halfToFloat(std::uint16_t value)


### PR DESCRIPTION
Union based type punning seems to be safer for int-float type conversion as it works around strict aliasing rules, which improves portability.

This PR is related to Gentoo bug [940326](https://bugs.gentoo.org/940326).