### PR TITLE
Add `sys/select.h` include

### DIFF
--- a/Sources/nCine/Application.cpp
+++ b/Sources/nCine/Application.cpp
@@ -170,6 +170,7 @@ static bool EnableVirtualTerminalProcessing(HANDLE consoleHandleOut)
 }
 #elif (defined(DEATH_TARGET_APPLE) || defined(DEATH_TARGET_UNIX)) && !defined(DEATH_TARGET_SWITCH)
 #	include <termios.h>
+#	include <sys/select.h>
 
 static void CheckConsoleDarkMode()
 {


### PR DESCRIPTION
It is necessary to explicitly include `sys/select.h` for some platforms, e.g. systems with musl libc.

Bug: https://bugs.gentoo.org/942772