### PR TITLE
Write actual value of sfx volume into cache

### DIFF
--- a/Sources/Jazz2/Compatibility/JJ2Data.cpp
+++ b/Sources/Jazz2/Compatibility/JJ2Data.cpp
@@ -167,7 +167,7 @@ namespace Jazz2::Compatibility
 				so.WriteValue<std::uint16_t>(0);
 			}
 
-			so.WriteValue<std::uint8_t>((std::uint8_t)std::max(sfx.Volume * 255 / 0x40, (std::uint32_t)UINT8_MAX));
+			so.WriteValue<std::uint8_t>((std::uint8_t)std::min(sfx.Volume * 255 / 0x40, (std::uint32_t)UINT8_MAX));
 			so.WriteValue<std::int8_t>((std::int8_t)std::clamp(((std::int32_t)sfx.Panning - 0x20) * INT8_MAX / /*0x20*/0x40, -(std::int32_t)INT8_MAX, (std::int32_t)INT8_MAX));
 		}
 


### PR DESCRIPTION
This PR fixes the volume of all cutscene sfx being written wrong into the cache. Instead of their actual value, the maximum value of 255 was always written.

For this fix to work, the cache needs to be rebuilt.  

Note that there's currently a bug preventing the playback of any SFX during the intro cutscene when the game is started with no cache. This means to test this, you'll need to delete the cache, start the game once, exit properly and then start the game again to have sfx during the intro.