### PR TITLE
Fall back to local Source/ when Content is packaged on Linux

### DIFF
--- a/Sources/Jazz2/ContentResolver.cpp
+++ b/Sources/Jazz2/ContentResolver.cpp
@@ -206,21 +206,12 @@ namespace Jazz2
 #	if defined(NCINE_PACKAGED_CONTENT_PATH)
 		// If Content is packaged with binaries, prefer a local Source/ for portable use and
 		// fall back to standard XDG paths otherwise.
-		// AppRun cds into the AppImage mount point before launching, so CWD is useless.
-		// Check candidate base directories in order:
-		//   1. $OWD  — original working directory set by the AppImage runtime (where the user
-		//              launched the AppImage from, i.e. next to their Source/ folder)
-		//   2. dirname($APPIMAGE) — directory containing the .AppImage file itself
-		//   3. XDG data path (default)
+		// AppRun cds into the AppImage mount point before launching, so CWD is useless —
+		// use dirname($APPIMAGE) to resolve paths relative to the .AppImage file itself.
 		String localBase;
-		StringView owdEnv = ::getenv("OWD");
-		if (!owdEnv.empty()) {
-			localBase = owdEnv;
-		} else {
-			StringView appImageEnv = ::getenv("APPIMAGE");
-			if (!appImageEnv.empty()) {
-				localBase = fs::GetDirectoryName(appImageEnv);
-			}
+		StringView appImageEnv = ::getenv("APPIMAGE");
+		if (!appImageEnv.empty()) {
+			localBase = fs::GetDirectoryName(appImageEnv);
 		}
 
 		String localSourcePath = fs::CombinePath(localBase, "Source/"_s);


### PR DESCRIPTION
## Problem

When a binary is built with `NCINE_PACKAGED_CONTENT_PATH` (e.g. the official AppImage and pre-built `.zip` releases), `ContentResolver::InitializePaths()` unconditionally resolves `Source/` and `Cache/` to `$XDG_DATA_HOME/jazz2/` (i.e. `~/.local/share/jazz2/`). There is no way to run the game portably with all files in one directory without manually creating symlinks.

## Fix

Before falling back to XDG paths, check whether `Source/Anims.j2a` or `Source/AnimsSw.j2a` exists relative to the working directory. If it does, use local relative paths for both `Source/` and `Cache/`. This mirrors the logic already present in the non-packaged (`#else`) branch, which has an equivalent fallback.

The XDG paths remain the default when no local source files are found, so existing installs are unaffected.

## Behaviour after this change

| Scenario | Source path used |
|---|---|
| Local `Source/Anims.j2a` present next to binary | `Source/` (relative) |
| No local source, `XDG_DATA_HOME` set | `$XDG_DATA_HOME/jazz2/Source/` |
| No local source, `XDG_DATA_HOME` unset | `~/.local/share/jazz2/Source/` |