### PR TITLE
Fix stack overflow issue on switch

### DIFF
--- a/Sources/Shared/IO/FileSystem.cpp
+++ b/Sources/Shared/IO/FileSystem.cpp
@@ -2374,7 +2374,15 @@ namespace Death { namespace IO {
 #		else
 		constexpr std::size_t BufferSize = 128 * 1024;
 #		endif
-		char buffer[BufferSize];
+		char* buffer;
+#		if defined(DEATH_TARGET_SWITCH)
+		// On Switch, large stack buffers are not supported. Use a heap buffer instead to avoid performance loss due to multiple small reads/writes with a small buffer.
+		auto heapBuffer = std::make_unique<char[]>(BufferSize);
+		buffer = heapBuffer.get();
+#		else
+		char stackBuffer[BufferSize];
+		buffer = stackBuffer;
+#		endif
 		bool success = true;
 		while (true) {
 			ssize_t bytesRead = ::read(sourceFd, buffer, BufferSize);


### PR DESCRIPTION
This PR fixes a startup/runtime crash on Nintendo Switch that was happening during file copy operations.

The root cause was stack pressure in the non-Linux copy path inside FileSystem::Copy. The function used a local copy buffer, and on Switch this could still contribute to stack exhaustion in worker threads with limited stack size, causing crashes right at function entry.

This bug might have surfaced due to recent changes to the switch operating system that reduced the amount of memory that homebrew apps have access to.

To address this safely without changing behavior on other platforms, the copy buffer allocation is now platform-specific:

- Switch now uses a heap-allocated buffer for the copy loop.
- Other platforms continue to use the existing stack buffer path.

Result  
- Prevents stack-related crashes in FileSystem::Copy on Switch.
- No functional change to copy semantics.

This change was tested on a switch oled, system version 21.2.0|AMS 1.10.2