### PR TITLE
Flight behavior adjustments and added `jjfly` cheat

### DIFF
--- a/Content/Metadata/Interactive/PlayerJazz.res
+++ b/Content/Metadata/Interactive/PlayerJazz.res
@@ -383,11 +383,14 @@
 		"Die": {
 			"Paths": [ "Common/gunsm1.wav" ]
 		},
-		"airboard": {
+		"Airboard": {
 			"Paths": [ "Common/char_airboard.wav" ]
 		},
-		"airboard_turn": {
-			"Paths": [ "Common/char_airboard_turn_1.wav", "Common/char_airboard_turn_2.wav" ]
+		"AirboardTurnStart": {
+			"Paths": [ "Common/char_airboard_turn_1.wav" ]
+		},
+		"AirboardTurnEnd": {
+			"Paths": [ "Common/char_airboard_turn_2.wav" ]
 		},
 		"Copter": {
 			"Paths": [ "Common/copter_noise.wav" ]

--- a/Content/Metadata/Interactive/PlayerJazz.res
+++ b/Content/Metadata/Interactive/PlayerJazz.res
@@ -383,6 +383,12 @@
 		"Die": {
 			"Paths": [ "Common/gunsm1.wav" ]
 		},
+		"airboard": {
+			"Paths": [ "Common/char_airboard.wav" ]
+		},
+		"airboard_turn": {
+			"Paths": [ "Common/char_airboard_turn_1.wav", "Common/char_airboard_turn_2.wav" ]
+		},
 		"Copter": {
 			"Paths": [ "Common/copter_noise.wav" ]
 		},

--- a/Content/Metadata/Interactive/PlayerLori.res
+++ b/Content/Metadata/Interactive/PlayerLori.res
@@ -368,11 +368,14 @@
 		"Die": {
 			"Paths": [ "Lori/die.wav" ]
 		},
-		"airboard": {
+		"Airboard": {
 			"Paths": [ "Common/char_airboard.wav" ]
 		},
-		"airboard_turn": {
-			"Paths": [ "Common/char_airboard_turn_1.wav", "Common/char_airboard_turn_2.wav" ]
+		"AirboardTurnStart": {
+			"Paths": [ "Common/char_airboard_turn_1.wav" ]
+		},
+		"AirboardTurnEnd": {
+			"Paths": [ "Common/char_airboard_turn_2.wav" ]
 		},
 		"Copter": {
 			"Paths": [ "Common/copter_noise.wav" ]

--- a/Content/Metadata/Interactive/PlayerLori.res
+++ b/Content/Metadata/Interactive/PlayerLori.res
@@ -368,6 +368,12 @@
 		"Die": {
 			"Paths": [ "Lori/die.wav" ]
 		},
+		"airboard": {
+			"Paths": [ "Common/char_airboard.wav" ]
+		},
+		"airboard_turn": {
+			"Paths": [ "Common/char_airboard_turn_1.wav", "Common/char_airboard_turn_2.wav" ]
+		},
 		"Copter": {
 			"Paths": [ "Common/copter_noise.wav" ]
 		},

--- a/Content/Metadata/Interactive/PlayerSpaz.res
+++ b/Content/Metadata/Interactive/PlayerSpaz.res
@@ -375,6 +375,12 @@
 		"Die": {
 			"Paths": [ "Spaz/idle_flavor_4.wav" ]
 		},
+		"airboard": {
+			"Paths": [ "Common/char_airboard.wav" ]
+		},
+		"airboard_turn": {
+			"Paths": [ "Common/char_airboard_turn_1.wav", "Common/char_airboard_turn_2.wav" ]
+		},
 		"Copter": {
 			"Paths": [ "Common/copter_noise.wav" ]
 		},

--- a/Content/Metadata/Interactive/PlayerSpaz.res
+++ b/Content/Metadata/Interactive/PlayerSpaz.res
@@ -375,11 +375,14 @@
 		"Die": {
 			"Paths": [ "Spaz/idle_flavor_4.wav" ]
 		},
-		"airboard": {
+		"Airboard": {
 			"Paths": [ "Common/char_airboard.wav" ]
 		},
-		"airboard_turn": {
-			"Paths": [ "Common/char_airboard_turn_1.wav", "Common/char_airboard_turn_2.wav" ]
+		"AirboardTurnStart": {
+			"Paths": [ "Common/char_airboard_turn_1.wav" ]
+		},
+		"AirboardTurnEnd": {
+			"Paths": [ "Common/char_airboard_turn_2.wav" ]
 		},
 		"Copter": {
 			"Paths": [ "Common/copter_noise.wav" ]

--- a/Sources/Jazz2/Actors/Collectibles/CarrotFlyCollectible.cpp
+++ b/Sources/Jazz2/Actors/Collectibles/CarrotFlyCollectible.cpp
@@ -28,7 +28,8 @@ namespace Jazz2::Actors::Collectibles
 
 	void CarrotFlyCollectible::OnCollect(Player* player)
 	{
-		if (player->SetModifier(Player::Modifier::Copter)) {
+		// Collect the item even if the player is already in Copter; otherwise switch to Copter first and collect only on success.
+		if (player->GetModifier() == Player::Modifier::Copter || player->SetModifier(Player::Modifier::Copter)) {
 			CollectibleBase::OnCollect(player);
 		}
 	}

--- a/Sources/Jazz2/Actors/Player.cpp
+++ b/Sources/Jazz2/Actors/Player.cpp
@@ -298,6 +298,11 @@ namespace Jazz2::Actors
 		return (_inWater || _activeModifier != Modifier::None);
 	}
 
+	bool Player::IsInWater() const
+	{
+		return _inWater;
+	}
+
 	bool Player::IsContinuousJumpAllowed() const
 	{
 		return PreferencesCache::EnableContinuousJump;
@@ -2712,6 +2717,11 @@ namespace Jazz2::Actors
 			if (_pos.Y >= _levelHandler->GetWaterLevel() && _waterCooldownLeft <= 0.0f) {
 				_inWater = true;
 				_waterCooldownLeft = 20.0f;
+				_flyCheatActive = false;
+
+				if (_activeModifier == Modifier::Copter || _activeModifier == Modifier::Airboard) {
+					SetModifier(Modifier::None);
+				}
 
 				_controllable = true;
 				EndDamagingMove();
@@ -4192,6 +4202,10 @@ namespace Jazz2::Actors
 				_activeModifier = Modifier::None;
 
 #if defined(WITH_AUDIO)
+			if (_copterSound != nullptr) {
+				_copterSound->stop();
+				_copterSound = nullptr;
+			}
 			if (_airboardSound != nullptr) {
 				_airboardSound->stop();
 				_airboardSound = nullptr;

--- a/Sources/Jazz2/Actors/Player.cpp
+++ b/Sources/Jazz2/Actors/Player.cpp
@@ -68,6 +68,7 @@ namespace Jazz2::Actors
 		_copterFramesLeft(0.0f), _fireFramesLeft(0.0f), _pushFramesLeft(0.0f), _waterCooldownLeft(0.0f),
 		_levelExiting(LevelExitingState::None),
 		_isFreefall(false), _inWater(false), _isLifting(false), _isSpring(false),
+		_copterCheatActive(false),
 		_inShallowWater(-1),
 		_activeModifier(Modifier::None),
 		_externalForceCooldown(0.0f),
@@ -115,6 +116,14 @@ namespace Jazz2::Actors
 		if (_copterSound != nullptr) {
 			_copterSound->stop();
 			_copterSound = nullptr;
+		}
+		if (_airboardSound != nullptr) {
+			_airboardSound->stop();
+			_airboardSound = nullptr;
+		}
+		if (_airboardTurnSound != nullptr) {
+			_airboardTurnSound->stop();
+			_airboardTurnSound = nullptr;
 		}
 		if (_weaponSound != nullptr) {
 			_weaponSound->stop();
@@ -395,6 +404,20 @@ namespace Jazz2::Actors
 
 		OnUpdateTimers(timeMult);
 		OnHandleMovement(timeMult, areaWeaponAllowed, canJumpPrev);
+
+#if defined(WITH_AUDIO)
+		// Handle sequential airboard turn sounds
+		if (_airboardTurnSound != nullptr && !_airboardTurnSound->isPlaying()) {
+			// First sound finished, play the second sound now
+			auto it = _metadata->Sounds.find(String::nullTerminatedView("airboard_turn"_s));
+			if (it != _metadata->Sounds.end() && it->second.Buffers.size() >= 2) {
+				AudioBuffer* buffer2 = &it->second.Buffers[1]->Buffer;
+				LOGD("Playing airboard_turn buffer 2 (sequential)");
+				_levelHandler->PlaySfx(this, "airboard_turn"_s, buffer2, Vector3f::Zero, true, 2.0f, 0.8f);
+				_airboardTurnSound = nullptr;  // Reset for next turn
+			}
+		}
+#endif
 
 		// Handle weapon switching
 		if (((_controllable && _controllableExternal) || !_levelHandler->IsReforged()) && _playerType != PlayerType::Frog) {
@@ -779,6 +802,14 @@ namespace Jazz2::Actors
 				_copterSound = nullptr;
 			}
 		}
+		if (_airboardSound != nullptr) {
+			if ((_currentAnimation->State & AnimState::Airboard) == AnimState::Airboard) {
+				_airboardSound->setPosition(Vector3f(_pos.X, _pos.Y, 0.8f));
+			} else {
+				_airboardSound->stop();
+				_airboardSound = nullptr;
+			}
+		}
 #endif
 
 		// Trail
@@ -922,6 +953,19 @@ namespace Jazz2::Actors
 					SetFacingLeft(isFacingLeft);
 					// If player changed direction, reset push frames to prevent pushing animation
 					_pushFramesLeft = 0.0f;
+#if defined(WITH_AUDIO)
+					if (_activeModifier == Modifier::Airboard) {
+						// Play both turn sounds in sequence
+						auto it = _metadata->Sounds.find(String::nullTerminatedView("airboard_turn"_s));
+						if (it != _metadata->Sounds.end() && it->second.Buffers.size() >= 2) {
+							AudioBuffer* buffer1 = &it->second.Buffers[0]->Buffer;
+							LOGD("Playing airboard_turn buffer 1 (start sequence)");
+							_airboardTurnSound = _levelHandler->PlaySfx(this, "airboard_turn"_s, buffer1, Vector3f::Zero, true, 2.0f, 0.8f);
+						} else {
+							LOGD("Failed to find airboard_turn or not enough buffers");
+						}
+					}
+#endif
 				}
 
 				_isActivelyPushing = _wasActivelyPushing = true;
@@ -3025,6 +3069,10 @@ namespace Jazz2::Actors
 			_copterSound->stop();
 			_copterSound = nullptr;
 		}
+		if (_airboardSound != nullptr) {
+			_airboardSound->stop();
+			_airboardSound = nullptr;
+		}
 		if (_weaponSound != nullptr) {
 			_weaponSound->stop();
 			_weaponSound = nullptr;
@@ -4033,6 +4081,11 @@ namespace Jazz2::Actors
 		return _activeModifier;
 	}
 
+	void Player::EnableCopterCheat()
+	{
+		_copterCheatActive = true;
+	}
+
 	bool Player::SetModifier(Modifier modifier, const std::shared_ptr<ActorBase>& decor)
 	{
 		if (_activeModifier == modifier) {
@@ -4046,6 +4099,7 @@ namespace Jazz2::Actors
 
 		switch (modifier) {
 			case Modifier::Airboard: {
+				_copterCheatActive = false;
 				_controllable = true;
 				EndDamagingMove();
 				SetState(ActorState::ApplyGravitation, false);
@@ -4055,6 +4109,15 @@ namespace Jazz2::Actors
 				_internalForceY = 0.0f;
 
 				_activeModifier = Modifier::Airboard;
+
+#if defined(WITH_AUDIO)
+			if (_airboardSound == nullptr) {
+				_airboardSound = PlaySfx("airboard"_s, 0.6f, 1.0f);
+				if (_airboardSound != nullptr) {
+					_airboardSound->setLooping(true);
+				}
+			}
+#endif
 
 				MoveInstantly(Vector2f(0.0f, -16.0f), MoveType::Relative);
 				break;
@@ -4070,7 +4133,8 @@ namespace Jazz2::Actors
 
 				_activeModifier = Modifier::Copter;
 
-				_copterFramesLeft = 10.0f * FrameTimer::FramesPerSecond;
+				// If copter cheat is active, keep infinite duration; otherwise use default 10 seconds
+				_copterFramesLeft = _copterCheatActive ? 1e6f : (10.0f * FrameTimer::FramesPerSecond);
 
 #if defined(WITH_AUDIO)
 				if (_copterSound == nullptr) {
@@ -4083,6 +4147,7 @@ namespace Jazz2::Actors
 				break;
 			}
 			case Modifier::LizardCopter: {
+				_copterCheatActive = false;
 				_controllable = true;
 				EndDamagingMove();
 				SetState(ActorState::ApplyGravitation, false);
@@ -4095,12 +4160,23 @@ namespace Jazz2::Actors
 				_activeModifierDecor = decor;
 				_activeModifierDecor->OnDetach(this);
 
+
 				_copterFramesLeft = 3.0f * FrameTimer::FramesPerSecond;
 				break;
 			}
 
 			default: {
+				// No-wall cheat is only valid while flying: always restore tile collisions when modifier ends.
+				SetState(ActorState::CollideWithTileset | ActorState::CollideWithTilesetReduced, true);
+				_copterCheatActive = false;
 				_activeModifier = Modifier::None;
+
+#if defined(WITH_AUDIO)
+			if (_airboardSound != nullptr) {
+				_airboardSound->stop();
+				_airboardSound = nullptr;
+			}
+#endif
 
 				SetState(ActorState::CanJump | ActorState::ApplyGravitation, true);
 
@@ -4122,7 +4198,7 @@ namespace Jazz2::Actors
 		if (_currentTransition != nullptr && _currentTransition->State == AnimState::TransitionLedgeClimb) {
 			ForceCancelTransition();
 			MoveInstantly(Vector2f(IsFacingLeft() ? 6.0f : -6.0f, 0.0f), MoveType::Relative | MoveType::Force);
-		} else if (_activeModifier == Modifier::Copter || _activeModifier == Modifier::LizardCopter) {
+		} else if ((_activeModifier == Modifier::Copter || _activeModifier == Modifier::LizardCopter) && !_copterCheatActive) {
 			SetModifier(Modifier::None);
 		}
 
@@ -4138,7 +4214,9 @@ namespace Jazz2::Actors
 		_speed.X = 0.0f;
 		_internalForceY = 0.0f;
 		_fireFramesLeft = 0.0f;
-		_copterFramesLeft = 0.0f;
+		if (!_copterCheatActive) {
+			_copterFramesLeft = 0.0f;
+		}
 		_pushFramesLeft = 0.0f;
 		SetState(ActorState::CanJump, false);
 		_isAttachedToPole = false;

--- a/Sources/Jazz2/Actors/Player.cpp
+++ b/Sources/Jazz2/Actors/Player.cpp
@@ -112,6 +112,13 @@ namespace Jazz2::Actors
 			_spawnedBird->FlyAway();
 			_spawnedBird = nullptr;
 		}
+		StopAllActiveSounds();
+		// Release the shared palette offset back to the pool (e.g., on disconnect/level end)
+		ReleasePaletteOffset();
+	}
+
+	void Player::StopAllActiveSounds()
+	{
 #if defined(WITH_AUDIO)
 		if (_copterSound != nullptr) {
 			_copterSound->stop();
@@ -130,8 +137,6 @@ namespace Jazz2::Actors
 			_weaponSound = nullptr;
 		}
 #endif
-		// Release the shared palette offset back to the pool (e.g., on disconnect/level end)
-		ReleasePaletteOffset();
 	}
 
 	const Player::CharacterTraits& Player::GetCharacterTraits(PlayerType type)
@@ -413,11 +418,7 @@ namespace Jazz2::Actors
 #if defined(WITH_AUDIO)
 		if (_airboardTurnSound != nullptr && !_airboardTurnSound->isPlaying()) {
 			if (_activeModifier == Modifier::Airboard) {
-				auto it = _metadata->Sounds.find(String::nullTerminatedView("airboard_turn"_s));
-				if (it != _metadata->Sounds.end() && it->second.Buffers.size() >= 2) {
-					AudioBuffer* buffer2 = &it->second.Buffers[1]->Buffer;
-					_levelHandler->PlaySfx(this, "airboard_turn"_s, buffer2, Vector3f::Zero, true, 2.0f, 0.8f);
-				}
+				PlayPlayerSfx("AirboardTurnEnd"_s, 2.0f, 0.8f);
 			}
 			_airboardTurnSound = nullptr;
 		}
@@ -959,11 +960,7 @@ namespace Jazz2::Actors
 					_pushFramesLeft = 0.0f;
 #if defined(WITH_AUDIO)
 					if (_activeModifier == Modifier::Airboard) {
-						auto it = _metadata->Sounds.find(String::nullTerminatedView("airboard_turn"_s));
-						if (it != _metadata->Sounds.end() && it->second.Buffers.size() >= 2) {
-							AudioBuffer* buffer1 = &it->second.Buffers[0]->Buffer;
-							_airboardTurnSound = _levelHandler->PlaySfx(this, "airboard_turn"_s, buffer1, Vector3f::Zero, true, 2.0f, 0.8f);
-						}
+						_airboardTurnSound = PlayPlayerSfx("AirboardTurnStart"_s, 2.0f, 0.8f);
 					}
 #endif
 				}
@@ -3068,21 +3065,7 @@ namespace Jazz2::Actors
 	void Player::OnPerishInner()
 	{
 		_trailLastPos = _pos;
-
-#if defined(WITH_AUDIO)
-		if (_copterSound != nullptr) {
-			_copterSound->stop();
-			_copterSound = nullptr;
-		}
-		if (_airboardSound != nullptr) {
-			_airboardSound->stop();
-			_airboardSound = nullptr;
-		}
-		if (_weaponSound != nullptr) {
-			_weaponSound->stop();
-			_weaponSound = nullptr;
-		}
-#endif
+		StopAllActiveSounds();
 
 		SetState(ActorState::CanJump, false);
 		_speed.X = 0.0f;
@@ -4138,7 +4121,7 @@ namespace Jazz2::Actors
 
 #if defined(WITH_AUDIO)
 			if (_airboardSound == nullptr) {
-				_airboardSound = PlaySfx("airboard"_s, 0.6f, 1.0f);
+				_airboardSound = PlaySfx("Airboard"_s, 0.6f, 1.0f);
 				if (_airboardSound != nullptr) {
 					_airboardSound->setLooping(true);
 				}
@@ -4196,14 +4179,14 @@ namespace Jazz2::Actors
 				_activeModifier = Modifier::None;
 
 #if defined(WITH_AUDIO)
-			if (_copterSound != nullptr) {
-				_copterSound->stop();
-				_copterSound = nullptr;
-			}
-			if (_airboardSound != nullptr) {
-				_airboardSound->stop();
-				_airboardSound = nullptr;
-			}
+				if (_copterSound != nullptr) {
+					_copterSound->stop();
+					_copterSound = nullptr;
+				}
+				if (_airboardSound != nullptr) {
+					_airboardSound->stop();
+					_airboardSound = nullptr;
+				}
 #endif
 
 				SetState(ActorState::CanJump | ActorState::ApplyGravitation, true);

--- a/Sources/Jazz2/Actors/Player.cpp
+++ b/Sources/Jazz2/Actors/Player.cpp
@@ -1953,7 +1953,7 @@ namespace Jazz2::Actors
 	void Player::OnHitFloor(float timeMult)
 	{
 		if (_activeModifier == Modifier::None && (_currentAnimation->State & AnimState::Copter) == AnimState::Copter) {
-			SetCopterFlight(0.0f);
+			_copterFramesLeft = 0.0f;
 			SetAnimation(_currentAnimation->State & ~AnimState::Copter);
 			if (!_isAttachedToPole) {
 				SetState(ActorState::ApplyGravitation, true);
@@ -2092,7 +2092,7 @@ namespace Jazz2::Actors
 							_internalForceY = 0.0f;
 							_pushFramesLeft = 0.0f;
 							_fireFramesLeft = 0.0f;
-							SetCopterFlight(0.0f);
+							_copterFramesLeft = 0.0f;
 
 							// Stick the player to wall
 							MoveInstantly(Vector2f(IsFacingLeft() ? -6.0f : 6.0f, 0.0f), MoveType::Relative | MoveType::Force, params);
@@ -2104,7 +2104,7 @@ namespace Jazz2::Actors
 								SetState(ActorState::CanJump | ActorState::ApplyGravitation | ActorState::CollideWithTileset | ActorState::CollideWithSolidObjects, true);
 								_pushFramesLeft = 0.0f;
 								_fireFramesLeft = 0.0f;
-								SetCopterFlight(0.0f);
+								_copterFramesLeft = 0.0f;
 								_hitFloorTime = 60.0f;
 
 								_speed.Y = 0.0f;
@@ -2148,7 +2148,7 @@ namespace Jazz2::Actors
 		if (std::abs(force.X) > 0.0f) {
 			MoveInstantly(Vector2f(_pos.X, (_pos.Y + pos.Y) * 0.5f), MoveType::Absolute);
 
-			SetCopterFlight(0.0f);
+			_copterFramesLeft = 0.0f;
 			//speedX = force.X;
 			// Match the original real-time launch speed (70/60 baseline) when not Reforged
 			float springScaleX = (_levelHandler->IsReforged() ? 1.0f : LegacyFrameRateScale * 0.95f);
@@ -2184,7 +2184,7 @@ namespace Jazz2::Actors
 			MoveInstantly(Vector2f(lerp(_pos.X, pos.X, 0.3f), _pos.Y), MoveType::Absolute);
 
 			if (_activeModifier == Modifier::None && _copterFramesLeft > 0.0f) {
-				SetCopterFlight(0.0f);
+				_copterFramesLeft = 0.0f;
 				SetAnimation(_currentAnimation->State & ~AnimState::Copter);
 				SetState(ActorState::ApplyGravitation, true);
 			}
@@ -2556,7 +2556,7 @@ namespace Jazz2::Actors
 			}
 
 			if (cancelCopter) {
-				SetCopterFlight(0.0f);
+				_copterFramesLeft = 0.0f;
 				SetAnimation(_currentAnimation->State & ~AnimState::Copter);
 				if (!_isAttachedToPole) {
 					SetState(ActorState::ApplyGravitation, true);
@@ -2640,7 +2640,7 @@ namespace Jazz2::Actors
 				_externalForce.Y = 0.0f;
 				_isFreefall = false;
 				_isSpring = false;
-				SetCopterFlight(0.0f);
+				_copterFramesLeft = 0.0f;
 
 				if (newSuspendState == SuspendType::Hook || _wasFirePressed) {
 					_speed.X = 0.0f;
@@ -3086,7 +3086,7 @@ namespace Jazz2::Actors
 		_externalForce.Y = 0.0f;
 		_internalForceY = 0.0f;
 		_fireFramesLeft = 0.0f;
-		SetCopterFlight(0.0f);
+		_copterFramesLeft = 0.0f;
 		_pushFramesLeft = 0.0f;
 		_weaponCooldown = 0.0f;
 		_controllableTimeout = 0.0f;
@@ -3672,7 +3672,7 @@ namespace Jazz2::Actors
 		_controllable = false;
 		SetState(ActorState::IsInvulnerable | ActorState::ApplyGravitation, true);
 		_fireFramesLeft = 0.0f;
-		SetCopterFlight(0.0f);
+		_copterFramesLeft = 0.0f;
 		_pushFramesLeft = 0.0f;
 		_invulnerableTime = 0.0f;
 
@@ -3895,7 +3895,7 @@ namespace Jazz2::Actors
 			_externalForce.Y = 0.0f;
 			_internalForceY = 0.0f;
 			_fireFramesLeft = 0.0f;
-			SetCopterFlight(0.0f);
+			_copterFramesLeft = 0.0f;
 			_pushFramesLeft = 0.0f;
 
 			// For warping from the water
@@ -4010,7 +4010,7 @@ namespace Jazz2::Actors
 		_keepRunningTime = 0.0f;
 		_pushFramesLeft = 0.0f;
 		_fireFramesLeft = 0.0f;
-		SetCopterFlight(0.0f);
+		_copterFramesLeft = 0.0f;
 
 		SetAnimation(_currentAnimation->State & ~(AnimState::Uppercut /*| AnimState::Sidekick*/ | AnimState::Buttstomp));
 
@@ -4235,7 +4235,7 @@ namespace Jazz2::Actors
 		_internalForceY = 0.0f;
 		_fireFramesLeft = 0.0f;
 		if (!IsFlyCheatActive()) {
-			SetCopterFlight(0.0f);
+			_copterFramesLeft = 0.0f;
 		}
 		_pushFramesLeft = 0.0f;
 		SetState(ActorState::CanJump, false);

--- a/Sources/Jazz2/Actors/Player.cpp
+++ b/Sources/Jazz2/Actors/Player.cpp
@@ -411,15 +411,12 @@ namespace Jazz2::Actors
 		OnHandleMovement(timeMult, areaWeaponAllowed, canJumpPrev);
 
 #if defined(WITH_AUDIO)
-		// Handle sequential airboard turn sounds
 		if (_airboardTurnSound != nullptr && !_airboardTurnSound->isPlaying()) {
-			// First sound finished, play the second sound now
 			auto it = _metadata->Sounds.find(String::nullTerminatedView("airboard_turn"_s));
 			if (it != _metadata->Sounds.end() && it->second.Buffers.size() >= 2) {
 				AudioBuffer* buffer2 = &it->second.Buffers[1]->Buffer;
-				LOGD("Playing airboard_turn buffer 2 (sequential)");
 				_levelHandler->PlaySfx(this, "airboard_turn"_s, buffer2, Vector3f::Zero, true, 2.0f, 0.8f);
-				_airboardTurnSound = nullptr;  // Reset for next turn
+				_airboardTurnSound = nullptr;
 			}
 		}
 #endif
@@ -960,14 +957,10 @@ namespace Jazz2::Actors
 					_pushFramesLeft = 0.0f;
 #if defined(WITH_AUDIO)
 					if (_activeModifier == Modifier::Airboard) {
-						// Play both turn sounds in sequence
 						auto it = _metadata->Sounds.find(String::nullTerminatedView("airboard_turn"_s));
 						if (it != _metadata->Sounds.end() && it->second.Buffers.size() >= 2) {
 							AudioBuffer* buffer1 = &it->second.Buffers[0]->Buffer;
-							LOGD("Playing airboard_turn buffer 1 (start sequence)");
 							_airboardTurnSound = _levelHandler->PlaySfx(this, "airboard_turn"_s, buffer1, Vector3f::Zero, true, 2.0f, 0.8f);
-						} else {
-							LOGD("Failed to find airboard_turn or not enough buffers");
 						}
 					}
 #endif
@@ -4164,7 +4157,6 @@ namespace Jazz2::Actors
 
 				_activeModifier = Modifier::Copter;
 
-				// If fly cheat is active, keep infinite duration; otherwise use default 10 seconds
 				SetCopterFlight(_flyCheatActive ? 1e6f : (10.0f * FrameTimer::FramesPerSecond),
 					_flyCheatActive ? FlightType::Cheat : FlightType::Normal);
 

--- a/Sources/Jazz2/Actors/Player.cpp
+++ b/Sources/Jazz2/Actors/Player.cpp
@@ -412,12 +412,14 @@ namespace Jazz2::Actors
 
 #if defined(WITH_AUDIO)
 		if (_airboardTurnSound != nullptr && !_airboardTurnSound->isPlaying()) {
-			auto it = _metadata->Sounds.find(String::nullTerminatedView("airboard_turn"_s));
-			if (it != _metadata->Sounds.end() && it->second.Buffers.size() >= 2) {
-				AudioBuffer* buffer2 = &it->second.Buffers[1]->Buffer;
-				_levelHandler->PlaySfx(this, "airboard_turn"_s, buffer2, Vector3f::Zero, true, 2.0f, 0.8f);
-				_airboardTurnSound = nullptr;
+			if (_activeModifier == Modifier::Airboard) {
+				auto it = _metadata->Sounds.find(String::nullTerminatedView("airboard_turn"_s));
+				if (it != _metadata->Sounds.end() && it->second.Buffers.size() >= 2) {
+					AudioBuffer* buffer2 = &it->second.Buffers[1]->Buffer;
+					_levelHandler->PlaySfx(this, "airboard_turn"_s, buffer2, Vector3f::Zero, true, 2.0f, 0.8f);
+				}
 			}
+			_airboardTurnSound = nullptr;
 		}
 #endif
 
@@ -1203,7 +1205,7 @@ namespace Jazz2::Actors
 			if (!CanJump()) {
 				// Extend copter time
 				if (_copterFramesLeft > 0.0f) {
-					SetCopterFlight(70.0f, FlightType::Normal);
+					SetCopterFlight(70.0f, IsFlyCheatActive() ? FlightType::Cheat : FlightType::Normal);
 				}
 			} else if (_currentSpecialMove == SpecialMoveType::None && _jumpTime <= 0.0f && !_levelHandler->PlayerActionPressed(this, PlayerAction::Down)) {
 				// Standard jump

--- a/Sources/Jazz2/Actors/Player.cpp
+++ b/Sources/Jazz2/Actors/Player.cpp
@@ -68,7 +68,7 @@ namespace Jazz2::Actors
 		_copterFramesLeft(0.0f), _fireFramesLeft(0.0f), _pushFramesLeft(0.0f), _waterCooldownLeft(0.0f),
 		_levelExiting(LevelExitingState::None),
 		_isFreefall(false), _inWater(false), _isLifting(false), _isSpring(false),
-		_copterCheatActive(false),
+		_flyCheatActive(false),
 		_inShallowWater(-1),
 		_activeModifier(Modifier::None),
 		_externalForceCooldown(0.0f),
@@ -785,7 +785,7 @@ namespace Jazz2::Actors
 
 		// Copter
 		if (_activeModifier == Modifier::Copter || _activeModifier == Modifier::LizardCopter) {
-			_copterFramesLeft -= timeMult;
+			SetCopterFlight(_copterFramesLeft - timeMult, IsFlyCheatActive() ? FlightType::Cheat : FlightType::Normal);
 			if (_copterFramesLeft <= 0.0f) {
 				SetModifier(Modifier::None);
 			} else if (_activeModifierDecor != nullptr) {
@@ -1205,7 +1205,7 @@ namespace Jazz2::Actors
 			if (!CanJump()) {
 				// Extend copter time
 				if (_copterFramesLeft > 0.0f) {
-					_copterFramesLeft = 70.0f;
+					SetCopterFlight(70.0f, FlightType::Normal);
 				}
 			} else if (_currentSpecialMove == SpecialMoveType::None && _jumpTime <= 0.0f && !_levelHandler->PlayerActionPressed(this, PlayerAction::Down)) {
 				// Standard jump
@@ -1274,7 +1274,7 @@ namespace Jazz2::Actors
 						if ((_currentAnimation->State & AnimState::Copter) != AnimState::Copter) {
 							SetAnimation(AnimState::Copter);
 						}
-						_copterFramesLeft = 70.0f;
+						SetCopterFlight(70.0f, FlightType::Normal);
 #if defined(WITH_AUDIO)
 						if (_copterSound == nullptr) {
 							_copterSound = PlaySfx("Copter"_s, 0.6f, 1.5f);
@@ -1334,7 +1334,7 @@ namespace Jazz2::Actors
 						if ((_currentAnimation->State & AnimState::Copter) != AnimState::Copter) {
 							SetAnimation(AnimState::Copter);
 						}
-						_copterFramesLeft = 70.0f;
+						SetCopterFlight(70.0f, FlightType::Normal);
 #if defined(WITH_AUDIO)
 						if (_copterSound == nullptr) {
 							_copterSound = PlaySfx("Copter"_s, 0.6f, 1.5f);
@@ -1953,7 +1953,7 @@ namespace Jazz2::Actors
 	void Player::OnHitFloor(float timeMult)
 	{
 		if (_activeModifier == Modifier::None && (_currentAnimation->State & AnimState::Copter) == AnimState::Copter) {
-			_copterFramesLeft = 0.0f;
+			SetCopterFlight(0.0f);
 			SetAnimation(_currentAnimation->State & ~AnimState::Copter);
 			if (!_isAttachedToPole) {
 				SetState(ActorState::ApplyGravitation, true);
@@ -2092,7 +2092,7 @@ namespace Jazz2::Actors
 							_internalForceY = 0.0f;
 							_pushFramesLeft = 0.0f;
 							_fireFramesLeft = 0.0f;
-							_copterFramesLeft = 0.0f;
+							SetCopterFlight(0.0f);
 
 							// Stick the player to wall
 							MoveInstantly(Vector2f(IsFacingLeft() ? -6.0f : 6.0f, 0.0f), MoveType::Relative | MoveType::Force, params);
@@ -2104,7 +2104,7 @@ namespace Jazz2::Actors
 								SetState(ActorState::CanJump | ActorState::ApplyGravitation | ActorState::CollideWithTileset | ActorState::CollideWithSolidObjects, true);
 								_pushFramesLeft = 0.0f;
 								_fireFramesLeft = 0.0f;
-								_copterFramesLeft = 0.0f;
+								SetCopterFlight(0.0f);
 								_hitFloorTime = 60.0f;
 
 								_speed.Y = 0.0f;
@@ -2148,7 +2148,7 @@ namespace Jazz2::Actors
 		if (std::abs(force.X) > 0.0f) {
 			MoveInstantly(Vector2f(_pos.X, (_pos.Y + pos.Y) * 0.5f), MoveType::Absolute);
 
-			_copterFramesLeft = 0.0f;
+			SetCopterFlight(0.0f);
 			//speedX = force.X;
 			// Match the original real-time launch speed (70/60 baseline) when not Reforged
 			float springScaleX = (_levelHandler->IsReforged() ? 1.0f : LegacyFrameRateScale * 0.95f);
@@ -2184,7 +2184,7 @@ namespace Jazz2::Actors
 			MoveInstantly(Vector2f(lerp(_pos.X, pos.X, 0.3f), _pos.Y), MoveType::Absolute);
 
 			if (_activeModifier == Modifier::None && _copterFramesLeft > 0.0f) {
-				_copterFramesLeft = 0.0f;
+				SetCopterFlight(0.0f);
 				SetAnimation(_currentAnimation->State & ~AnimState::Copter);
 				SetState(ActorState::ApplyGravitation, true);
 			}
@@ -2549,14 +2549,14 @@ namespace Jazz2::Actors
 			if ((_currentAnimation->State & AnimState::Copter) == AnimState::Copter) {
 				cancelCopter = (CanJump() || _suspendType != SuspendType::None || _copterFramesLeft <= 0.0f);
 
-				_copterFramesLeft -= timeMult;
+				SetCopterFlight(_copterFramesLeft - timeMult, FlightType::Normal);
 				_speed.Y = std::min(_speed.Y + _levelHandler->GetGravity() * timeMult, 1.5f);
 			} else {
 				cancelCopter = ((_currentAnimation->State & AnimState::Fall) == AnimState::Fall && _copterFramesLeft > 0.0f);
 			}
 
 			if (cancelCopter) {
-				_copterFramesLeft = 0.0f;
+				SetCopterFlight(0.0f);
 				SetAnimation(_currentAnimation->State & ~AnimState::Copter);
 				if (!_isAttachedToPole) {
 					SetState(ActorState::ApplyGravitation, true);
@@ -2640,7 +2640,7 @@ namespace Jazz2::Actors
 				_externalForce.Y = 0.0f;
 				_isFreefall = false;
 				_isSpring = false;
-				_copterFramesLeft = 0.0f;
+				SetCopterFlight(0.0f);
 
 				if (newSuspendState == SuspendType::Hook || _wasFirePressed) {
 					_speed.X = 0.0f;
@@ -2887,7 +2887,7 @@ namespace Jazz2::Actors
 				break;
 			}
 			case EventType::AreaFlyOff: {
-				if (_activeModifier == Modifier::Airboard) {
+				if (_activeModifier == Modifier::Airboard && !IsFlyCheatActive()) {
 					SetModifier(Modifier::None);
 				}
 				break;
@@ -3086,7 +3086,7 @@ namespace Jazz2::Actors
 		_externalForce.Y = 0.0f;
 		_internalForceY = 0.0f;
 		_fireFramesLeft = 0.0f;
-		_copterFramesLeft = 0.0f;
+		SetCopterFlight(0.0f);
 		_pushFramesLeft = 0.0f;
 		_weaponCooldown = 0.0f;
 		_controllableTimeout = 0.0f;
@@ -3672,7 +3672,7 @@ namespace Jazz2::Actors
 		_controllable = false;
 		SetState(ActorState::IsInvulnerable | ActorState::ApplyGravitation, true);
 		_fireFramesLeft = 0.0f;
-		_copterFramesLeft = 0.0f;
+		SetCopterFlight(0.0f);
 		_pushFramesLeft = 0.0f;
 		_invulnerableTime = 0.0f;
 
@@ -3895,7 +3895,7 @@ namespace Jazz2::Actors
 			_externalForce.Y = 0.0f;
 			_internalForceY = 0.0f;
 			_fireFramesLeft = 0.0f;
-			_copterFramesLeft = 0.0f;
+			SetCopterFlight(0.0f);
 			_pushFramesLeft = 0.0f;
 
 			// For warping from the water
@@ -3950,7 +3950,7 @@ namespace Jazz2::Actors
 
 	void Player::InitialPoleStage(bool horizontal)
 	{
-		if (_isAttachedToPole || _playerType == PlayerType::Frog) {
+		if (_isAttachedToPole || _playerType == PlayerType::Frog || _activeModifier == Modifier::Copter || _activeModifier == Modifier::Airboard) {
 			return;
 		}
 		
@@ -4010,7 +4010,7 @@ namespace Jazz2::Actors
 		_keepRunningTime = 0.0f;
 		_pushFramesLeft = 0.0f;
 		_fireFramesLeft = 0.0f;
-		_copterFramesLeft = 0.0f;
+		SetCopterFlight(0.0f);
 
 		SetAnimation(_currentAnimation->State & ~(AnimState::Uppercut /*| AnimState::Sidekick*/ | AnimState::Buttstomp));
 
@@ -4081,9 +4081,31 @@ namespace Jazz2::Actors
 		return _activeModifier;
 	}
 
-	void Player::EnableCopterCheat()
+	bool Player::IsFlyCheatActive() const
 	{
-		_copterCheatActive = true;
+		return _flyCheatActive;
+	}
+
+	void Player::SetCopterFlight(float timeLeft, FlightType type)
+	{
+		if (timeLeft <= 0.0f) {
+			_copterFramesLeft = 0.0f;
+			_flyCheatActive = false;
+			return;
+		}
+
+		_copterFramesLeft = timeLeft;
+		_flyCheatActive = (type == FlightType::Cheat);
+	}
+
+	void Player::EnableFlyCheat()
+	{
+		_flyCheatActive = true;
+	}
+
+	void Player::DisableFlyCheat()
+	{
+		SetCopterFlight(0.0f);
 	}
 
 	bool Player::SetModifier(Modifier modifier, const std::shared_ptr<ActorBase>& decor)
@@ -4099,7 +4121,6 @@ namespace Jazz2::Actors
 
 		switch (modifier) {
 			case Modifier::Airboard: {
-				_copterCheatActive = false;
 				_controllable = true;
 				EndDamagingMove();
 				SetState(ActorState::ApplyGravitation, false);
@@ -4133,8 +4154,9 @@ namespace Jazz2::Actors
 
 				_activeModifier = Modifier::Copter;
 
-				// If copter cheat is active, keep infinite duration; otherwise use default 10 seconds
-				_copterFramesLeft = _copterCheatActive ? 1e6f : (10.0f * FrameTimer::FramesPerSecond);
+				// If fly cheat is active, keep infinite duration; otherwise use default 10 seconds
+				SetCopterFlight(_flyCheatActive ? 1e6f : (10.0f * FrameTimer::FramesPerSecond),
+					_flyCheatActive ? FlightType::Cheat : FlightType::Normal);
 
 #if defined(WITH_AUDIO)
 				if (_copterSound == nullptr) {
@@ -4147,7 +4169,6 @@ namespace Jazz2::Actors
 				break;
 			}
 			case Modifier::LizardCopter: {
-				_copterCheatActive = false;
 				_controllable = true;
 				EndDamagingMove();
 				SetState(ActorState::ApplyGravitation, false);
@@ -4161,13 +4182,13 @@ namespace Jazz2::Actors
 				_activeModifierDecor->OnDetach(this);
 
 
-				_copterFramesLeft = 3.0f * FrameTimer::FramesPerSecond;
+				SetCopterFlight(3.0f * FrameTimer::FramesPerSecond, FlightType::Normal);
 				break;
 			}
 
 			default: {
 				SetState(ActorState::CollideWithTileset | ActorState::CollideWithTilesetReduced, true);
-				_copterCheatActive = false;
+				SetCopterFlight(0.0f);
 				_activeModifier = Modifier::None;
 
 #if defined(WITH_AUDIO)
@@ -4197,7 +4218,7 @@ namespace Jazz2::Actors
 		if (_currentTransition != nullptr && _currentTransition->State == AnimState::TransitionLedgeClimb) {
 			ForceCancelTransition();
 			MoveInstantly(Vector2f(IsFacingLeft() ? 6.0f : -6.0f, 0.0f), MoveType::Relative | MoveType::Force);
-		} else if ((_activeModifier == Modifier::Copter || _activeModifier == Modifier::LizardCopter) && !_copterCheatActive) {
+		} else if ((_activeModifier == Modifier::Copter || _activeModifier == Modifier::LizardCopter) && !IsFlyCheatActive()) {
 			SetModifier(Modifier::None);
 		}
 
@@ -4213,8 +4234,8 @@ namespace Jazz2::Actors
 		_speed.X = 0.0f;
 		_internalForceY = 0.0f;
 		_fireFramesLeft = 0.0f;
-		if (!_copterCheatActive) {
-			_copterFramesLeft = 0.0f;
+		if (!IsFlyCheatActive()) {
+			SetCopterFlight(0.0f);
 		}
 		_pushFramesLeft = 0.0f;
 		SetState(ActorState::CanJump, false);

--- a/Sources/Jazz2/Actors/Player.cpp
+++ b/Sources/Jazz2/Actors/Player.cpp
@@ -4166,7 +4166,6 @@ namespace Jazz2::Actors
 			}
 
 			default: {
-				// No-wall cheat is only valid while flying: always restore tile collisions when modifier ends.
 				SetState(ActorState::CollideWithTileset | ActorState::CollideWithTilesetReduced, true);
 				_copterCheatActive = false;
 				_activeModifier = Modifier::None;

--- a/Sources/Jazz2/Actors/Player.h
+++ b/Sources/Jazz2/Actors/Player.h
@@ -618,6 +618,7 @@ namespace Jazz2::Actors
 		void DoWarpOut(Vector2f pos, WarpFlags flags);
 		void InitialPoleStage(bool horizontal);
 		void NextPoleStage(bool horizontal, bool positive, std::int32_t stagesLeft, float lastSpeed);
+		void StopAllActiveSounds();
 
 		void OnPerishInner();
 

--- a/Sources/Jazz2/Actors/Player.h
+++ b/Sources/Jazz2/Actors/Player.h
@@ -103,6 +103,12 @@ namespace Jazz2::Actors
 			Shielded			/**< Invulnerable due to an active shield */
 		};
 
+		/** @brief Type of copter flight state */
+		enum class FlightType {
+			Normal,				/**< Timed/regular flight */
+			Cheat				/**< Cheat-enabled flight */
+		};
+
 		/**
 			@brief Constant per-character properties
 
@@ -221,8 +227,14 @@ namespace Jazz2::Actors
 		Modifier GetModifier() const;
 		/** @brief Sets current modifier */
 		virtual bool SetModifier(Modifier modifier, const std::shared_ptr<ActorBase>& decor = nullptr);
-		/** @brief Enables copter cheat behavior for the next cheat copter activation */
-		void EnableCopterCheat();
+		/** @brief Returns whether fly-cheat behavior is currently active */
+		bool IsFlyCheatActive() const;
+		/** @brief Sets copter flight duration and type (`timeLeft <= 0` disables flight cheat state) */
+		void SetCopterFlight(float timeLeft, FlightType type = FlightType::Normal);
+		/** @brief Enables fly cheat behavior for the next cheat flight activation */
+		void EnableFlyCheat();
+		/** @brief Disables fly cheat behavior */
+		void DisableFlyCheat();
 		/** @brief Takes damage */
 		virtual bool TakeDamage(std::int32_t amount, float pushForce = 0.0f, bool ignoreInvulnerable = false);
 		/** @brief Freezes the player for specified time */
@@ -435,7 +447,7 @@ namespace Jazz2::Actors
 		float _copterFramesLeft, _fireFramesLeft, _pushFramesLeft, _waterCooldownLeft;
 		LevelExitingState _levelExiting;
 		bool _isFreefall, _inWater, _isLifting, _isSpring;
-		bool _copterCheatActive;
+		bool _flyCheatActive;
 		std::int32_t _inShallowWater;
 		Modifier _activeModifier;
 		bool _inIdleTransition, _inLedgeTransition;

--- a/Sources/Jazz2/Actors/Player.h
+++ b/Sources/Jazz2/Actors/Player.h
@@ -201,6 +201,8 @@ namespace Jazz2::Actors
 		bool CanBreakSolidObjects() const;
 		/** @brief Returns `true` if the player can move vertically, i.e. not affected by gravity */
 		bool CanMoveVertically() const;
+		/** @brief Returns `true` if the player is currently in water */
+		bool IsInWater() const;
 		/** @brief Returns `true` if continuous jump is allowed */
 		virtual bool IsContinuousJumpAllowed() const;
 		/** @brief Returns `true` if ledge climbing is allowed */

--- a/Sources/Jazz2/Actors/Player.h
+++ b/Sources/Jazz2/Actors/Player.h
@@ -221,6 +221,8 @@ namespace Jazz2::Actors
 		Modifier GetModifier() const;
 		/** @brief Sets current modifier */
 		virtual bool SetModifier(Modifier modifier, const std::shared_ptr<ActorBase>& decor = nullptr);
+		/** @brief Enables copter cheat behavior for the next cheat copter activation */
+		void EnableCopterCheat();
 		/** @brief Takes damage */
 		virtual bool TakeDamage(std::int32_t amount, float pushForce = 0.0f, bool ignoreInvulnerable = false);
 		/** @brief Freezes the player for specified time */
@@ -433,6 +435,7 @@ namespace Jazz2::Actors
 		float _copterFramesLeft, _fireFramesLeft, _pushFramesLeft, _waterCooldownLeft;
 		LevelExitingState _levelExiting;
 		bool _isFreefall, _inWater, _isLifting, _isSpring;
+		bool _copterCheatActive;
 		std::int32_t _inShallowWater;
 		Modifier _activeModifier;
 		bool _inIdleTransition, _inLedgeTransition;
@@ -457,6 +460,8 @@ namespace Jazz2::Actors
 		void ReleasePaletteOffset();
 #if defined(WITH_AUDIO)
 		std::shared_ptr<AudioBufferPlayer> _copterSound;
+		std::shared_ptr<AudioBufferPlayer> _airboardSound;
+		std::shared_ptr<AudioBufferPlayer> _airboardTurnSound;
 #endif
 
 		std::int32_t _lives, _score;

--- a/Sources/Jazz2/LevelHandler.cpp
+++ b/Sources/Jazz2/LevelHandler.cpp
@@ -2556,7 +2556,7 @@ namespace Jazz2
 			}
 			// Set cheat mode flag if switching to Copter
 			if (nextModifier == Actors::Player::Modifier::Copter) {
-				player->EnableCopterCheat();
+				player->EnableFlyCheat();
 			}
 			player->SetModifier(nextModifier);
 		}

--- a/Sources/Jazz2/LevelHandler.cpp
+++ b/Sources/Jazz2/LevelHandler.cpp
@@ -2540,7 +2540,6 @@ namespace Jazz2
 	void LevelHandler::CheatFly()
 	{
 		for (auto* player : _players) {
-			// Cheat only works for Jazz, Spaz, and Lori
 			PlayerType playerType = player->GetPlayerType();
 			if (playerType != PlayerType::Jazz &&
 				playerType != PlayerType::Spaz &&
@@ -2559,7 +2558,6 @@ namespace Jazz2
 				case Actors::Player::Modifier::Copter:  nextModifier = Actors::Player::Modifier::Airboard; break;
 				default:                                nextModifier = Actors::Player::Modifier::None;     break;
 			}
-			// Set cheat mode flag if switching to Copter
 			if (nextModifier == Actors::Player::Modifier::Copter) {
 				player->EnableFlyCheat();
 			}

--- a/Sources/Jazz2/LevelHandler.cpp
+++ b/Sources/Jazz2/LevelHandler.cpp
@@ -2424,6 +2424,7 @@ namespace Jazz2
 			{ "jjcoins"_s, {}, &LevelHandler::CheatCoins },
 			{ "jjmorph"_s, {}, &LevelHandler::CheatMorph },
 			{ "jjshield"_s, {}, &LevelHandler::CheatShield },
+			{ "jjfly"_s, {}, &LevelHandler::CheatFly },
 		};
 
 		for (const auto& cheat : CheatCommands) {
@@ -2532,6 +2533,32 @@ namespace Jazz2
 		for (auto* player : _players) {
 			ShieldType shieldType = (ShieldType)(((std::int32_t)player->GetActiveShield() + 1) % (std::int32_t)ShieldType::Count);
 			player->SetShield(shieldType, 40.0f * FrameTimer::FramesPerSecond);
+		}
+	}
+
+
+	void LevelHandler::CheatFly()
+	{
+		for (auto* player : _players) {
+			// Cheat only works for Jazz, Spaz, and Lori
+			PlayerType playerType = player->GetPlayerType();
+			if (playerType != PlayerType::Jazz &&
+				playerType != PlayerType::Spaz &&
+				playerType != PlayerType::Lori) {
+				continue;
+			}
+			
+			Actors::Player::Modifier nextModifier;
+			switch (player->GetModifier()) {
+				case Actors::Player::Modifier::None:    nextModifier = Actors::Player::Modifier::Copter;   break;
+				case Actors::Player::Modifier::Copter:  nextModifier = Actors::Player::Modifier::Airboard; break;
+				default:                                nextModifier = Actors::Player::Modifier::None;     break;
+			}
+			// Set cheat mode flag if switching to Copter
+			if (nextModifier == Actors::Player::Modifier::Copter) {
+				player->EnableCopterCheat();
+			}
+			player->SetModifier(nextModifier);
 		}
 	}
 

--- a/Sources/Jazz2/LevelHandler.cpp
+++ b/Sources/Jazz2/LevelHandler.cpp
@@ -2547,6 +2547,11 @@ namespace Jazz2
 				playerType != PlayerType::Lori) {
 				continue;
 			}
+
+			if (player->IsInWater()) {
+				player->DisableFlyCheat();
+				continue;
+			}
 			
 			Actors::Player::Modifier nextModifier;
 			switch (player->GetModifier()) {

--- a/Sources/Jazz2/LevelHandler.h
+++ b/Sources/Jazz2/LevelHandler.h
@@ -396,5 +396,6 @@ namespace Jazz2
 		void CheatCoins();
 		void CheatMorph();
 		void CheatShield();
+		void CheatFly();
 	};
 }


### PR DESCRIPTION
This PR introduces the `jjfly` cheat and aligns key flight interactions with expected JJ2-style behavior.

### What `jjfly` does
- Adds a new cheat command: `jjfly`
- Cycles the player flight modifier in this order:
  - `None -> Copter -> Airboard -> None`

### Flight behavior adjustments included
- While flying (`Copter` or `Airboard`), vine and pole interactions no longer interrupt flight:
  - passing through `SwingingVine` does not attach/suspend
  - pole events are ignored during active flight
- Flying carrot behavior is now consistent with expected gameplay:
  - collecting a flying carrot while already in `Copter` only collects the item (no state change)
  - collecting it while in `Airboard` switches flight from `Airboard` to `Copter`
  
  ### Flight state helper (`SetCopterFlight`)
- Added a dedicated helper (`SetCopterFlight`) to centralize Copter flight state updates.
- The function provides a single place to manage:
  - remaining copter flight time (`_copterFramesLeft`)
  - cheat-aware flight state (`_flyCheatActive`) when relevant
- This reduces scattered state handling and makes flight transitions (`None`/`Copter`/`Airboard`) easier to reason about and maintain.
  
  ### Airboard audio behavior
- Added dedicated Airboard SFX handling when entering Airboard mode (`PlaySfx("airboard", ...)`).
- The Airboard sound is looped while Airboard is active, so flight feedback stays continuous.
- Audio is cleaned up when Airboard is no longer active (loop is stopped and the player handle is released), preventing stale/overlapping playback.
- This keeps audio transitions consistent when switching between flight states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `jjfly` cheat, cycling supported characters through normal, Copter, and Airboard flight modes.
  * Added cheat-enabled flight controls, including status persistence during damage and flight-area transitions.
  * Added separate Airboard turn-start and turn-end sound effects.
  * Added automatic disabling of flight cheat mode when entering water or when flight expires.

* **Bug Fixes**
  * Carrot Fly collectibles can now be collected when Copter mode is already active.
  * Improved cleanup of flight effects and sounds during state changes, damage, death, and modifier removal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->